### PR TITLE
Fixing APNs environment for TestFlight builds

### DIFF
--- a/hooks/useDeviceToken.tsx
+++ b/hooks/useDeviceToken.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { DevicePushToken, getDevicePushTokenAsync, requestPermissionsAsync } from 'expo-notifications'
-import { getIosPushNotificationServiceEnvironmentAsync, applicationId } from 'expo-application';
+import { getIosPushNotificationServiceEnvironmentAsync, getIosApplicationReleaseTypeAsync, applicationId, ApplicationReleaseType } from 'expo-application';
 import { Credentials } from './useAuth';
 import { UserClient } from 'magicbell/user-client';
 import { Platform } from 'react-native';
@@ -19,7 +19,8 @@ const tokenPath = Platform.select({
 
 
 const apnsTokenPayload = async (token: string): any => {
-  const installationId = await getIosPushNotificationServiceEnvironmentAsync() || 'development'
+  const isSimulator = await getIosApplicationReleaseTypeAsync() === ApplicationReleaseType.SIMULATOR
+  const installationId = await getIosPushNotificationServiceEnvironmentAsync() || isSimulator ? 'development' : 'production'
   return {
     apns: {
       device_token: token,


### PR DESCRIPTION
## Change description

Testflight expects a `production` apns environment.

> Production provisioning profile and [Prerelease Versions and Beta Testers](https://developer.apple.com/documentation/AppStoreConnectAPI/prerelease-versions-and-beta-testers) use production.

Source: https://developer.apple.com/documentation/bundleresources/entitlements/aps-environment

The idea is
1st: Use the environment that expo could look up
2nd: If expo did not provide an env, fall back to development on simulator
3rd: Fallback to production in other cases (this is the TestFlight case)

## Test Plan

<!-- How did you test the changes, what are the suggested steps for reviewers if they want to test your changes? -->

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->
