### PR TITLE
feat: Support for opening app from review PRs (internal)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,26 +1,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <uses-permission android:name="android.permission.INTERNET" />
-
-    <application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme"
-      android:supportsRtl="true">
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
-        android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize"
-        android:exported="true">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-    </application>
+  <uses-permission android:name="android.permission.INTERNET"/>
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:theme="@style/AppTheme" android:supportsRtl="true">
+    <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="x-magicbell-review"/>
+      </intent-filter>
+    </activity>
+  </application>
 </manifest>

--- a/hooks/useReviewCredentials.tsx
+++ b/hooks/useReviewCredentials.tsx
@@ -1,0 +1,73 @@
+import {useLinkingURL} from 'expo-linking';
+
+import {Credentials} from './useAuth';
+import {useMemo} from 'react';
+
+function parseJwtToken(token: string) {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split('')
+      .map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join(''),
+  );
+
+  return JSON.parse(jsonPayload);
+}
+
+/**
+ * Parses a launch URL and if is a review environment connection URL, uses the embedded credentials to sign in to the app.
+ * 
+ * ATTENTION: This is only for MagicBell internal use. You should not follow this example in your production app.
+ *
+ * Example URL:
+ *  x-magicbell-review://connect?api-host=http://localhost:3000&project-jwt-token=abcdef.....abcdef
+ */
+const parseLaunchURLCredentials = (launchURL: URL): Credentials | null => {
+  const apiHost = launchURL.searchParams.get('api-host');
+  const projectJWTToken = launchURL.searchParams.get('project-jwt-token');
+  if (!apiHost || !projectJWTToken) {
+    console.warn(
+      "Expected parameters [ 'api-host', 'project-jwt-token' ] but got:",
+      Array.from(launchURL.searchParams.keys()),
+    );
+    return null;
+  }
+
+  const tokenData = parseJwtToken(projectJWTToken);
+  const apiKey = tokenData['ProjectKey']['APIKey'];
+  const credentials: Credentials = {
+    apiKey: apiKey,
+    userEmail: 'review@magicbell.io',
+    userHmac: '',
+    serverURL: apiHost,
+  };
+  console.log('Credentials from launch URL:', credentials);
+  return credentials;
+};
+
+export default function useReviewCredentials(): Credentials | null {
+  const launchURL = useLinkingURL();
+  return useMemo(() => {
+    if (!launchURL) {
+      return null;
+    }
+
+    try {
+      const url = new URL(launchURL);
+
+      // ignore non review connect URLs
+      if (url.protocol !== 'x-magicbell-review:' || url.host !== 'connect') {
+        return null;
+      }
+
+      return parseLaunchURLCredentials(url);
+    } catch (error) {
+      console.warn('Could not parse launch URL: ', error);
+      return null;
+    }
+  }, [launchURL]);
+}

--- a/ios/MobileInbox/Info.plist
+++ b/ios/MobileInbox/Info.plist
@@ -20,6 +20,15 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>x-magicbell-review</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -17,6 +17,8 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (14.0.1):
     - ExpoModulesCore
+  - ExpoLinking (7.0.3):
+    - ExpoModulesCore
   - ExpoModulesCore (2.1.2):
     - DoubleConversion
     - glog
@@ -1826,6 +1828,7 @@ DEPENDENCIES:
   - ExpoFileSystem (from `../node_modules/expo-file-system/ios`)
   - ExpoFont (from `../node_modules/expo-font/ios`)
   - ExpoKeepAwake (from `../node_modules/expo-keep-awake/ios`)
+  - ExpoLinking (from `../node_modules/expo-linking/ios`)
   - ExpoModulesCore (from `../node_modules/expo-modules-core`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
@@ -1922,6 +1925,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-font/ios"
   ExpoKeepAwake:
     :path: "../node_modules/expo-keep-awake/ios"
+  ExpoLinking:
+    :path: "../node_modules/expo-linking/ios"
   ExpoModulesCore:
     :path: "../node_modules/expo-modules-core"
   FBLazyVector:
@@ -2071,6 +2076,7 @@ SPEC CHECKSUMS:
   ExpoFileSystem: a38e1bb58d77f41717293a7b73ebd4014d8cb8dd
   ExpoFont: b089994dac1fe603deda1cec151e32c81f46c2f1
   ExpoKeepAwake: 22173f45d767c7d37403fdf48292726901d69ce7
+  ExpoLinking: 40e30b571ffb77b280a38bed137d89b21f46f2a0
   ExpoModulesCore: 9e0b600d2489daaace1e5813f18253ed14bb6e55
   FBLazyVector: be509404b5de73a64a74284edcaf73a5d1e128b1
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/native-stack": "^6.9.22",
     "expo": "^52.0.0",
     "expo-application": "~6.0.1",
+    "expo-linking": "~7.0.3",
     "expo-notifications": "~0.29.11",
     "native-base": "^3.4.28",
     "react": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5810,6 +5810,14 @@ expo-keep-awake@~14.0.1:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-14.0.1.tgz#77c38feefa95c494aa167e6df5a6eacd17af2358"
   integrity sha512-c5mGCAIk2YM+Vsdy90BlEJ4ZX+KG5Au9EkJUIxXWlpnuKmDAJ3N+5nEZ7EUO1ZTheqoSBeAo4jJ8rTWPU+JXdw==
 
+expo-linking@~7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/expo-linking/-/expo-linking-7.0.3.tgz#307851288ec65e1c533bcc70b57dfb6372f9679e"
+  integrity sha512-YiDacNzeQZd/bdOwGyi+YlawM4GGbcSRkuFCpDGIK7D1KUGqLinBHwJvxUMb9Zert2Ois5IHtmZaZ1et6g229g==
+  dependencies:
+    expo-constants "~17.0.0"
+    invariant "^2.2.4"
+
 expo-modules-autolinking@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/expo-modules-autolinking/-/expo-modules-autolinking-2.0.4.tgz#28fcd12fb0d066a2933cca3bf3b597da0f6b2f2a"


### PR DESCRIPTION
## Change description

This adds support for `x-magicbell-review://connect?api-host=http://localhost:3000&project-jwt-token=abcdef.....abcdef` URL handling. This is not something anyone outside of MagicBell should be using, and is just there to ease with internal testing.

### Test Plan

Tested the app when logged out on both, shut down and started (on credentials screen).

iOS:
`xcrun simctl openurl booted x-magicbell-review://connect?api-host=http://localhost:3000&project-jwt-token=abcdef.....abcdef`

Android (note, the double quoting is needed for `adb`, [see here](https://stackoverflow.com/a/13620028/25724)):
`adb shell am start -d '"x-magicbell-review://connect?api-host=http://localhost:3000&project-jwt-token=abcdef.....abcdef"'

## Test Plan

<!-- How did you test the changes, what are the suggested steps for reviewers if they want to test your changes? -->

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->
