### PR TITLE
feat: Add instructions for APNs notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,73 @@ At this point you can use the keyboard shortcuts on the dashboard to build and o
 If you want to launch the app on a specific simulator or even device, you can use the `shift+i`/`shift+a` shortcuts, or start another build process from the terminal while keeping Metro in the background by running `yarn ios` or `yarn android` (both of which support additional parameters that can be inspected by passing `-h`).
 
 ## Sending FCM Notifications
-To send notifications with FCM, you will need a [Firebase account](https://firebase.google.com/) and an Android app. You can create the app by using the `Add app` button on your console and selecting android.
-You should now see a button that says, `google-service.json`, using which you can download the `google-service.json` file.
 
-If you have a pre-registered app then you can go into the Project Settings of the app, and in the General tab, you can find the button to download `google-service.json` in the Your apps section.
+To send notifications with FCM, you will need to configure Mobile Inbox:
 
-After downloading the file replace `google-service.json` file in the root of this project with your file.
+You will need a [Firebase account](https://firebase.google.com/) and a Firebase Android app. 
 
-To launch the Android app you can use:
+1. You can create the Firebase Android app by using the `Add app` button on your Firebase console and selecting Android.
+
+2. Download the `google-service.json` file.
+If you're creating a new app, then, after adding your Android package name, you should see a button labelled `Download google-service.json`, which allows you to download the `google-service.json` file.
+If you have a pre-registered app, you can access the Project Settings of the app and, in the General tab, locate the button to download `google-service.json` in the "Your apps" section.
+
+3. Replace the `google-service.json` file in the root of this project with the downloaded file.
+
+4. Do a clean build and launch the Android app:
+
 ```bash
 yarn android:clean
 ```
 
-The command will do a clean Android build and launch the Android app in an emulator. 
-
-For authentication, you will need a MagicBell userJWT, you can [generate it using your MagicBell API Key and the external ID of the user](https://www.magicbell.com/docs/api/authentication/user) you want to send notifications to. 
+5. For authentication, you will need a MagicBell user JWT. You can [generate it using your MagicBell API Key and the external ID of the user](https://www.magicbell.com/docs/api/authentication/user) you want to send notifications to. 
 
 To test if you are receiving notifications correctly, you can use the [FCM Test](https://www.magicbell.com/test/fcm).
 
-You will need an Admin SDK private key, you can get it from your firebase console by going to the Project Settings by clicking on the gear button on the left sidebar. Then going to Service Accounts and clicking the `Generate new private key`, it will save a JSON file to your machine that you can then upload to the [MagicBell FCM Test](https://www.magicbell.com/test/fcm) page.
+6. You will need an Admin SDK private key.
+You can obtain it from your Firebase console. 
+Click on the gear icon in the left sidebar, then navigate to the Service Accounts tab and click `Generate new private key`, which saves a JSON file to your machine. 
+
+7. Upload the private key JSON file to the [MagicBell FCM Test](https://www.magicbell.com/test/fcm) page.
+
+8. Copy the generated Device Token from the console running the Expo app.
+The token will look like: 
+
+```
+posting token c2RAxxT6Qae-USMxxxQQhF:APA91bFxxmo7G_xBwBhiFl[...]FTrVU183-pxx4
+```
+
+9. Enter the device token on the [MagicBell FCM Test](https://www.magicbell.com/test/fcm) page and click `Send Notification.`
+
+## Sending APNs Notifications
+
+To send APNs Notifications, you need to start by configuring the Mobile Inbox Expo app.
+
+1. Update `appleTeamId` and the `bundleIdentifier` in the `app.json` file.
+Update the Team ID to the value configured with your project.
+
+2. Do a clean build of the iOS App:
+
+```bash
+yarn ios:clean
+```
+
+You can test the APNs Notification, using the [MagicBell APNs Test Page](https://www.magicbell.com/test/apns) and authenticating as a MagicBell user on the Mobile Inbox app.
+
+3. Go to the [MagicBell APNs Test Page](https://www.magicbell.com/test/apns) and enter your App ID, Certificate, Key ID, Team ID, and Badge to configure APNs.
+
+4. [Generate a userJWT](https://www.magicbell.com/docs/api/authentication/user) with your MagicBell API Key and the external ID of the user.
+
+5. Enter the User JWT and the v2 API URL, `"https://api.magicbell.com/v2"`, and Sign In.
+
+6. Copy the generated Device Token from the console running the Expo app.
+The token will look like: 
+
+```
+posting token 801bd597ba34abf2[...]1017df7a47fd6b14cbbf
+```
+
+7. Enter the Device Token on the [MagicBell APNs Test Page](https://www.magicbell.com/test/apns), select `development` as the Installation ID and click `Send Notification.`
 
 ## Building Release Builds
 

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "usesCleartextTraffic": true
     },
     "ios": {
-      "appleTeamId": "7847W99F5L",
+      "appleTeamId": "46V5H8FFSN",
       "bundleIdentifier": "com.magicbell.mobile-inbox",
       "config": {
         "usesNonExemptEncryption": false

--- a/src/components/MagicBellProvider.tsx
+++ b/src/components/MagicBellProvider.tsx
@@ -38,7 +38,7 @@ type MagicBellProviderProps = {
 };
 
 export default function MagicBellProvider({ children }: MagicBellProviderProps) {
-  const [credentials] = useCredentials();
+  const [credentials, _, signOut] = useCredentials();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -56,6 +56,7 @@ export default function MagicBellProvider({ children }: MagicBellProviderProps) 
   const fetchNotifications = useCallback(
     async (params?: ListNotificationsParams) => {
       if (!client) {
+        signOut();
         setError(new Error('MagicBell client not initialized'));
         return;
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,7 +77,7 @@ export const config: { [key: string]: Credentials } = {
   prod: {
     serverURL: 'https://api.magicbell.com/v2',
     userJWT:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2VtYWlsIjpudWxsLCJ1c2VyX2V4dGVybmFsX2lkIjoiN2Y0YmFhYjUtMGM5MS00NGU4LThiNTgtNWZmODQ5NTM1MTc0IiwiYXBpX2tleSI6IjVmNWNmYjI5NTEzODQ2NDMzZTgxYjkxZWM1ZTkwOGM5NDNmZjYwNTgiLCJpYXQiOjE3NjM1NDMyOTksImV4cCI6MTc2MzYyOTY5OX0.NzZcuIv_g-nW0JAhF0i_pH4T96BHCfkdjkJOLnqvF6M',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2VtYWlsIjpudWxsLCJ1c2VyX2V4dGVybmFsX2lkIjoiN2Y0YmFhYjUtMGM5MS00NGU4LThiNTgtNWZmODQ5NTM1MTc0IiwiYXBpX2tleSI6IjVmNWNmYjI5NTEzODQ2NDMzZTgxYjkxZWM1ZTkwOGM5NDNmZjYwNTgiLCJpYXQiOjE3NjM5NzE1MTEsImV4cCI6MTc5NTUyOTExMX0.4Zty_YgwQKPsD8mNHqaneesrRe9XTtK5hlfj0RPl82Q',
   },
   local: {
     serverURL: 'https://1b35-79-153-3-135.ngrok-free.app',

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -21,7 +21,7 @@ export default function HomeScreen(): React.JSX.Element {
     <SafeAreaView style={styles.sectionContainer}>
       <ScrollView style={styles.scrollable}>
         {isLoading && <ActivityIndicator size="large" />}
-        {error && <Text>Error: {error.message}</Text>}
+        {error && <Text style={{ color: '#FFFFFF' }}>Error: {error.message}</Text>}
         {notifications?.map((notification) => (
           <Notification key={notification.id} data={notification} />
         ))}


### PR DESCRIPTION
## Change description

- Fixes a login page bug for iOS
- Adds instructions to send APNs Notifications using Mobile Inbox
- Grammarly checks on Firebase and APNs instructions
- Itemise Firebase instructions 

Demo of sending APNs Push Notification:

https://github.com/user-attachments/assets/bcb7a308-c019-41bc-b289-4a9f6a295d3f


<!-- Describe the most significant changes. Focus on the _why_, more than the _what_. -->

## Test Plan

<!-- How did you test the changes, what are the suggested steps for reviewers if they want to test your changes? -->

## Type of Change

- [ ] Bug fix      <!-- fixes an issue -->
- [ ] Feature      <!-- adds functionality -->
- [ ] Enhancement  <!-- improves something existing -->
